### PR TITLE
Bug 1148341 - livelog: fix name references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /node_modules
+/livelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ MAINTAINER James Lal [:lightsofapollo] <jlal@mozilla.com>
 
 EXPOSE 60023
 EXPOSE 60022
-COPY target/continuous-log-serve  /continuous-log-serve
-ENTRYPOINT ["/continuous-log-serve"]
+COPY target/livelog  /livelog
+ENTRYPOINT ["/livelog"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# continuous-log-serve
+# livelog
 
 ## TODO
   - [x] byte range fetching

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ fi
 echo "Building proxy server..."
 # Output folder
 mkdir -p target
-GOARCH=amd64 GOOS=linux go build -o target/continuous-log-serve .
+GOARCH=amd64 GOOS=linux go build -o target/livelog .
 
 echo "Building docker image for proxy server"
 docker build -t $1 .

--- a/main.go
+++ b/main.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"sync"
 
-	stream "github.com/lightsofapollo/continuous-log-serve/writer"
+	stream "github.com/taskcluster/livelog/writer"
 	. "github.com/visionmedia/go-debug"
 )
 
-var debug = Debug("continuous-log-serve")
+var debug = Debug("livelog")
 
 func abort(writer http.ResponseWriter) error {
 	// We need to hijack and abort the request...

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "continuous-log-serve",
+  "name": "livelog",
   "version": "0.0.0",
   "description": "Tests only for the go package...",
   "private": true,
@@ -12,14 +12,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/lightsofapollo/continuous-log-serve.git"
+    "url": "git://github.com/taskcluster/livelog.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/lightsofapollo/continuous-log-serve/issues"
+    "url": "https://github.com/taskcluster/livelog/issues"
   },
-  "homepage": "https://github.com/lightsofapollo/continuous-log-serve",
+  "homepage": "https://github.com/taskcluster/livelog",
   "dependencies": {
     "mocha": "^1.21.4",
     "promise": "^5.0.0",

--- a/test/launch.js
+++ b/test/launch.js
@@ -7,7 +7,7 @@ var waitForPort = require('./wait_for_port');
 
 module.exports = function launch() {
   return new Promise(function(accept, reject) {
-    var proc = spawn(__dirname + '/../continuous-log-serve', [], {
+    var proc = spawn(__dirname + '/../livelog', [], {
       env: process.env,
       stdio: 'inherit'
     });

--- a/writer/stream.go
+++ b/writer/stream.go
@@ -37,7 +37,7 @@ type Stream struct {
 }
 
 func NewStream(read io.Reader) (*Stream, error) {
-	dir, err := ioutil.TempDir("", "continuous-log-serve")
+	dir, err := ioutil.TempDir("", "livelog")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
from:
```
github.com/lightsofapollo/continuous-log-serve
```
to:
```
github.com/taskcluster/livelog
```