### PR TITLE
Add ca-certificates to container, and base on busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:14.04
+FROM progrium/busybox
 MAINTAINER James Lal [:lightsofapollo] <jlal@mozilla.com>
+
+RUN opkg-install ca-certificates
 
 EXPOSE 60023
 EXPOSE 60022


### PR DESCRIPTION
Two things:
 1. Add `ca-certificates` for some reason it won't serve SSL without it. Probably because it needs to be able to establish the entire chain, or maybe it just wants to...
 2. Base on busybox instead of ubuntu (`progrium/busybox` has `opkg-install`, so we can get certs in), space optimization is pretty obvious from the list below.

```
[livelog]$docker images | grep livelog
quay.io/mozilla/livelog   v3   ef4f13107115        24 seconds ago      12.94 MB
quay.io/mozilla/livelog   v2   d240993cb4f9        31 minutes ago      275 MB
quay.io/mozilla/livelog   v1   401798bd6110        6 weeks ago         196.2 MB
```