### PR TITLE
Specifying chunked transfer for live logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,8 @@ func getLog(
 	// intentions...
 	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	writer.Header().Set("Access-Control-Allow-Origin", "*")
+	writer.Header().Set("Transfer-Encoding", "chunked")
+	writer.Header().Set("Access-Control-Expose-Headers", "Transfer-Encoding")
 
 	log.Printf("%v", req.Header)
 

--- a/main.go
+++ b/main.go
@@ -96,7 +96,6 @@ func getLog(
 	// intentions...
 	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	writer.Header().Set("Access-Control-Allow-Origin", "*")
-	writer.Header().Set("Transfer-Encoding", "chunked")
 	writer.Header().Set("Access-Control-Expose-Headers", "Transfer-Encoding")
 
 	log.Printf("%v", req.Header)


### PR DESCRIPTION
The intent behind this is to be able to determine in the Unified Logviewer whether a log being displayed is streamed or not. Since these are accessed via CORS, we don't have access to `Content-Length` to sniff that. Instead, I'm attempting to go this generic route by saying the log is streamed with `chunked`, which seems pretty standard, then exposing the header to JS.