### PR TITLE
Make port numbers configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 before_install:
 # workaround for travis-ci/gimme#42
-  - curl -o go.tar.gz -sL https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz
+  - curl -o go.tar.gz -sL https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz
   - tar -C $HOME -xf go.tar.gz
   - rm go.tar.gz
   - export GOROOT="${HOME}/go"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Livelog is a service that enables both secure and insecure streaming of binary
 content (typically log files) over HTTP(S).
 
 It achieves this by exposing an interface for receiving log data via an HTTP
-PUT request on tcp port 60022, and exposing a separate interface for reading
-the log via HTTP GET on port 60023.
+PUT request (typically on tcp port 60022), and exposing a separate interface
+for reading the log via HTTP GET typically on port 60023.
 
 It is written in go, which compiles to a native binary for most conceivable
 platforms, and can therefore be deployed almost anywhere.
@@ -31,8 +31,19 @@ interface has been initiated.
 
 ## URLs
 
+When used with default ports:
+
 * PUT: http(s)://localhost:60022/log
 * GET: http(s)://localhost:60023/log/`${ACCESS_TOKEN}`
+
+To alter the port numbers, set environment variables `LIVELOG_PUT_PORT` and/or
+`LIVELOG_GET_PORT` to the preferred values when starting the livelog server.
+For example, in bash:
+
+```
+export LIVELOG_PUT_PORT=32815
+export LIVELOG_GET_PORT=32844
+```
 
 `ACCESS_TOKEN` is an arbitrary url-safe string that you provide via the
 `ACCESS_TOKEN` environment variable to the livelog process when it starts up.
@@ -101,3 +112,5 @@ The following environment variables can be used to configure the server.
  * `SERVER_CRT_FILE` path to SSL certificate file (optional)
  * `SERVER_KEY_FILE` path to SSL private key file (optional)
  * `DEBUG` set to '*' to see debug logs (optional)
+ * `LIVELOG_PUT_PORT` PUT port number (optional - default is 60022)
+ * `LIVELOG_GET_PORT` GET port number (optional - default is 60023)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "go build && mocha $(find test -name '*.js')"
+    "test": "go build && LIVELOG_PUT_PORT= LIVELOG_GET_PORT= mocha $(find test -name '*.js')"
   },
   "repository": {
     "type": "git",

--- a/writer/stream.go
+++ b/writer/stream.go
@@ -139,7 +139,7 @@ func (self *Stream) Consume() error {
 			}
 
 			pendingWrites := len(handle.events)
-			if pendingWrites >= (EVENT_BUFFER_SIZE - 1) {
+			if pendingWrites >= EVENT_BUFFER_SIZE-1 {
 				log.Printf("Removing handle with %d pending writes\n", pendingWrites)
 				// Remove the handle from any future event writes...
 				self.Unobserve(handle)


### PR DESCRIPTION
Previously, port numbers were hardcoded. This led to a problem testing livelog in taskcluster, because the worker itself was running a livelog, and this clashed with the livelog server that the test tries to start.

This is a simple patch to make the ports configurable via env vars. I chose to use env vars rather than command line options since livelog already uses env vars for configuration, and doesn't currently implement any command line parsing. Also, we are intending at some point to switch from having livelog servers on our workers, in favour of a centralised live logging service - so introducing command line parsing at this time seems not worth it.