### PR TITLE
Stop using (unsupported) https://github.com/fatih/set

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,5 +225,6 @@ func main() {
 
 	// Listen forever on the PUT side...
 	log.Printf("input server listening... %s", server.Addr)
-	server.ListenAndServe()
+	err := server.ListenAndServe()
+	log.Fatalf("%s", err)
 }


### PR DESCRIPTION
We had a dependency on [github.com/fatih/set](https://github.com/fatih/set) which is no longer maintained/supported. Sets of type `X` can be trivially implemented in go as `map[X]struct{}` or `map[X]bool`, so importing a set library wasn't necessary. I've therefore removed [github.com/fatih/set](https://github.com/fatih/set) and used a `map[X]struct{}` construction instead.